### PR TITLE
Undo global kubernetes client timeout

### DIFF
--- a/cmd/pomerium-operator/root_test.go
+++ b/cmd/pomerium-operator/root_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/pomerium/pomerium-operator/internal/deploymentmanager"
 	"github.com/spf13/pflag"
@@ -172,7 +171,6 @@ users: []`
 	kcfg, err := getConfig()
 	assert.NoError(t, err)
 	assert.NotNil(t, kcfg)
-	assert.Equal(t, 15*time.Second, kcfg.Timeout)
 }
 
 func Test_bindViper(t *testing.T) {


### PR DESCRIPTION
This setting breaks the controller watch calls.  It should only be set for object managers.