### PR TITLE
Add ConfigManager to Manager start 

### DIFF
--- a/cmd/pomerium-operator/root.go
+++ b/cmd/pomerium-operator/root.go
@@ -91,9 +91,11 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		go configManager.Start()
+		if err := o.Add(configManager); err != nil {
+			return err
+		}
 
-		if err = o.Start(); err != nil {
+		if err := o.Start(); err != nil {
 			logger.Error(err, "operator failed to start.  exiting")
 			return err
 		}

--- a/internal/configmanager/configmanager.go
+++ b/internal/configmanager/configmanager.go
@@ -173,7 +173,9 @@ func (c *ConfigManager) GetPersistedConfig() (options pomeriumconfig.Options, er
 	return
 }
 
-// Start begins the periodic save loop to persist in-memory configuration to the API
+// Start implements manager.Runnable
+//
+//begins the periodic save loop to persist in-memory configuration to the API
 func (c *ConfigManager) Start(stopCh <-chan struct{}) error {
 	for {
 		select {

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -90,6 +90,11 @@ func (o *Operator) Start() error {
 	return nil
 }
 
+// Add ensures a manager.Runnable is started with the rest of the operator
+func (o *Operator) Add(f manager.Runnable) error {
+	return o.mgr.Add(f)
+}
+
 // CreateController registers a new Reconciler with the Operator and associates it with an object type to handle events for.
 func (o *Operator) CreateController(reconciler reconcile.Reconciler, name string, object runtime.Object) error {
 	log.L.V(1).Info("adding controller", "name", name, "kind", object.GetObjectKind().GroupVersionKind().Kind)


### PR DESCRIPTION
Binds ConfigManger's Start() to the controller manager Start() after leader election.

This prevents flushing of base config from non-leader replicas at startup.