### PR TITLE
Store config in Secret instead of ConfigMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ This ingress:
 2. Maps `grafana.pomerium.io` to the service at `prometheus-grafana`
 3. Permits all users from domain `pomerium.io` to access this endpoint
 
-The appropriate policy entry will be generated and injected into the pomerium `ConfigMap`:
+The appropriate policy entry will be generated and injected into the pomerium config `Secret`:
 
 ```yaml
 apiVersion: v1
-data:
+stringData:
   config.yaml: |
     policy:
     - from: https://grafana.pomerium.io

--- a/cmd/pomerium-operator/root.go
+++ b/cmd/pomerium-operator/root.go
@@ -39,7 +39,7 @@ type cmdConfig struct {
 	MetricsAddress      string
 	HealthAddress       string
 	Namespace           string
-	PomeriumConfigMap   string
+	PomeriumSecret      string
 	PomeriumNamespace   string
 	PomeriumDeployments []string
 	ServiceClass        string
@@ -114,7 +114,7 @@ func main() {
 func init() {
 	rootCmd.PersistentFlags().Bool("debug", false, "Run in debug mode")
 	rootCmd.PersistentFlags().StringP("namespace", "n", "", "Namespaces to monitor")
-	rootCmd.PersistentFlags().String("pomerium-configmap", "pomerium", "Name of pomerium ConfigMap to maintain")
+	rootCmd.PersistentFlags().String("pomerium-secret", "pomerium", "Name of pomerium Secret to maintain")
 	rootCmd.PersistentFlags().String("pomerium-namespace", "kube-system", "Name of pomerium ConfigMap to maintain")
 	rootCmd.PersistentFlags().String("base-config-file", "./pomerium-base.yaml", "Path to base configuration file")
 
@@ -154,7 +154,7 @@ func newRestClient(config *rest.Config) (client.Client, error) {
 
 func newConfigManager(kClient client.Client) (cm *configmanager.ConfigManager, err error) {
 	baseConfigFile := operatorCfg.BaseConfigFile
-	cm = configmanager.NewConfigManager(operatorCfg.PomeriumNamespace, operatorCfg.PomeriumConfigMap, kClient, time.Second*10)
+	cm = configmanager.NewConfigManager(operatorCfg.PomeriumNamespace, operatorCfg.PomeriumSecret, kClient, time.Second*10)
 
 	baseBytes, err := ioutil.ReadFile(baseConfigFile)
 	if err != nil {

--- a/internal/configmanager/configmanager_test.go
+++ b/internal/configmanager/configmanager_test.go
@@ -35,14 +35,14 @@ func mockBaseConfigBytes(t *testing.T) []byte {
 
 func newMockClient(t *testing.T) client.Client {
 
-	configMap := &corev1.ConfigMap{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pomerium",
 			Namespace: "test",
 		},
-		Data: make(map[string]string),
+		Data: make(map[string][]byte),
 	}
-	client := fake.NewFakeClient(configMap)
+	client := fake.NewFakeClient(secret)
 	return client
 }
 
@@ -165,12 +165,12 @@ func Test_Save(t *testing.T) {
 		})
 	}
 
-	configMap := &corev1.ConfigMap{}
-	err = client.Get(context.Background(), types.NamespacedName{Name: cm.configMap, Namespace: cm.namespace}, configMap)
-	assert.NoError(t, err, "failed to get configMap")
+	secret := &corev1.Secret{}
+	err = client.Get(context.Background(), types.NamespacedName{Name: cm.secret, Namespace: cm.namespace}, secret)
+	assert.NoError(t, err, "failed to get secret")
 
 	resultOptions := pomeriumconfig.Options{}
-	configBytes := []byte(configMap.Data[configKey])
+	configBytes := []byte(secret.Data[configKey])
 	err = yaml.Unmarshal(configBytes, &resultOptions)
 	assert.NoError(t, err, "failed to unmarshal resulting config")
 

--- a/internal/controller/reconciler_test.go
+++ b/internal/controller/reconciler_test.go
@@ -135,7 +135,7 @@ func fakeObjects() []runtime.Object {
 
 func Test_Reconcile_2(t *testing.T) {
 
-	testConfigMap := corev1.ConfigMap{
+	testSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",
@@ -205,7 +205,7 @@ func Test_Reconcile_2(t *testing.T) {
 				Name:      tt.obj.(metav1.Object).GetName(),
 			}
 
-			c := fake.NewFakeClient(&testConfigMap)
+			c := fake.NewFakeClient(&testSecret)
 			cm := configmanager.NewConfigManager("test", "test", c, time.Nanosecond*1)
 			r := NewReconciler(tt.obj, "pomerium", cm)
 			err := r.InjectClient(c)

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -21,7 +21,7 @@ type Options struct {
 	NameSpace               string
 	ServiceClass            string
 	IngressClass            string
-	ConfigMap               string
+	Secret                  string
 	Client                  manager.NewClientFunc
 	KubeConfig              *rest.Config
 	MapperProvider          func(*rest.Config) (meta.RESTMapper, error)


### PR DESCRIPTION
Fixes pomerium/pomerium-helm#67.

I've done my best with the naming, hope that config stored in the `Secret` is not confusing.

Also, I've changed the `Secret` name used in the tests to the new default (from `pomerium` to `pomerium-config`).