### PR TITLE
Persist configuration unconditionally with CreateOrUpdate()

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -485,6 +485,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.6.2 h1:7aKfF+e8/k68gda3LOjo5RxiUqddoFxVq4BKBPrxk5E=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
+github.com/spf13/viper v1.6.3 h1:pDDu1OyEDTKzpJwdq4TiuLyMsUgRa/BT5cn5O62NoHs=
 github.com/spf13/viper v1.6.3/go.mod h1:jUMtyi0/lB5yZH/FjyGAoH7IMNrIhlBf6pXZmbMDvzw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/configmanager/configmanager_test.go
+++ b/internal/configmanager/configmanager_test.go
@@ -217,10 +217,10 @@ func Test_Save(t *testing.T) {
 
 }
 
-func Test_Save_clientError(t *testing.T) {
+func Test_Save_create(t *testing.T) {
 
 	cm := NewConfigManager("test", "pomerium", fake.NewFakeClient(), time.Nanosecond*1)
-	assert.Error(t, cm.Save())
+	assert.NoError(t, cm.Save())
 
 }
 
@@ -289,6 +289,6 @@ func Test_OnSave(t *testing.T) {
 	err = cm.Save()
 
 	assert.NoError(t, err)
-	assert.Equal(t, 3, callback.called)
+	assert.Equal(t, 1, callback.called)
 	assert.Empty(t, cmp.Diff(persistedConfig, callback.calledConfig, cmpopts.IgnoreUnexported(pomeriumconfig.Options{})))
 }


### PR DESCRIPTION
Remove logic to track our updates and, instead, rely on controller-runtime's
CreateOrUpdate() logic to handle diffing.  The result is that we will
ensure the persisted config is up to date every settlePeriod seconds.

